### PR TITLE
fix(README): use the correct example image name

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [[English](README.md) | [Portuguese](README.pt.md)]
 
-Build a responsive microsite to display the weather forecast at the locations given in the white text box (in the [example](./example.jpg) image is where "Rio de Janeiro, Rio de Janeiro" appears. This text box should be an `input`, where the user can change the location. With the change of location, the weather forecast information for the new location must be loaded.
+Build a responsive microsite to display the weather forecast at the locations given in the white text box (in the [example](./exemplo.jpg) image is where "Rio de Janeiro, Rio de Janeiro" appears. This text box should be an `input`, where the user can change the location. With the change of location, the weather forecast information for the new location must be loaded.
 
 Once the page is opened, the user's geographic coordinates must be collected by the browser API to discover the city name via _reverse geocode_.
 


### PR DESCRIPTION
## O que esse PR faz:

Resolve o problema de não encontrar o exemplo no README em inglês.

## Antes
Ao clicar mostrava a seguinte página:
![image](https://user-images.githubusercontent.com/35539594/174646299-6dfc24c4-d1a4-4698-843c-e816061a67c1.png)

## Depois

Agora mostra corretamente o exemplo